### PR TITLE
docs: new ungrammer location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tools for [ungrammar][1].
 
-[1]: https://github.com/rust-analyzer/ungrammar
+[1]: https://github.com/rust-lang/rust-analyzer/tree/master/lib/ungrammar
 
 ## Install
 


### PR DESCRIPTION
ungrammer moved to the rust-lang org